### PR TITLE
fix: add access control headers

### DIFF
--- a/lambda_handlers/hubapi_list.py
+++ b/lambda_handlers/hubapi_list.py
@@ -139,7 +139,8 @@ def _return_json_builder(body, status):
     return {
         "isBase64Encoded": False,
         "headers": {
-            "Content-Type": "application/json"
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin":"*"
         },
         "statusCode": int(status),
         "body": body

--- a/lambda_handlers/hubapi_push.py
+++ b/lambda_handlers/hubapi_push.py
@@ -114,7 +114,8 @@ def _return_json_builder(body, status):
     return {
         "isBase64Encoded": False,
         "headers": {
-            "Content-Type": "application/json"
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin":"*"
         },
         "statusCode": int(status),
         "body": body


### PR DESCRIPTION
- Add `Access-Control-Allow-Origin` to list and push headers
This allows access from any browser client, see https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS for more info