### PR TITLE
Set larger timeoutSeconds in case timeout issue raise CrashLoopBackOff problem

### DIFF
--- a/k8s_example/demo_k8s_flow/k8s/deployment_pod0.yaml
+++ b/k8s_example/demo_k8s_flow/k8s/deployment_pod0.yaml
@@ -54,6 +54,7 @@ spec:
               - jina ping 0.0.0.0 $PORT_CTRL
           initialDelaySeconds: 30
           periodSeconds: 30
+          timeoutSeconds: 30
         readinessProbe:
           exec:
             command:
@@ -61,4 +62,5 @@ spec:
               - -c
               - jina ping 0.0.0.0 $PORT_CTRL
           initialDelaySeconds: 30
-          periodSeconds: 30
+          periodSeconds: 30 
+          timeoutSeconds: 30

--- a/k8s_example/demo_k8s_flow/k8s/deployment_pod1.yaml
+++ b/k8s_example/demo_k8s_flow/k8s/deployment_pod1.yaml
@@ -53,7 +53,8 @@ spec:
               - -c
               - jina ping 0.0.0.0 $PORT_CTRL
           initialDelaySeconds: 30
-          periodSeconds: 30
+          periodSeconds: 30 
+          timeoutSeconds: 30
         readinessProbe:
           exec:
             command:
@@ -61,4 +62,5 @@ spec:
               - -c
               - jina ping 0.0.0.0 $PORT_CTRL
           initialDelaySeconds: 30
-          periodSeconds: 30
+          periodSeconds: 30 
+          timeoutSeconds: 30


### PR DESCRIPTION
Set larger timeoutSeconds in case timeout issue raise CrashLoopBackOff problem, the problem looks like 
![image](https://user-images.githubusercontent.com/10429190/105972409-8c62ac00-60c6-11eb-913e-71c47a5fbd19.png)
