### PR TITLE
fix(deb-systemd.sh): use option  when install jinad

### DIFF
--- a/scripts/deb-systemd.sh
+++ b/scripts/deb-systemd.sh
@@ -21,7 +21,7 @@ sudo bash <<INIT
     # install python packages except jinad
     python3.8 -m pip install --target /usr/local/jina $*
     # install jinad
-    python3.8 -m pip install --target /usr/local/jina --pre "jina[daemon]"
+    python3.8 -m pip install --upgrade --target /usr/local/jina --pre "jina[daemon]"
 INIT
 
 echo -e "\n\nInstalling jinad as daemon\n"


### PR DESCRIPTION
Otherwise we cannot install `jinad` successfully by `deb-systemd.sh` with an error:
```
 jinad.service: Failed at step EXEC spawning /usr/local/jina/bin/jinad: No such file or directory
```