### PR TITLE
fix: install latest jina release, not pre

### DIFF
--- a/scripts/deb-systemd.sh
+++ b/scripts/deb-systemd.sh
@@ -21,7 +21,7 @@ sudo bash <<INIT
     mkdir /usr/local/jina/tmp
     TMPDIR=/usr/local/jina/tmp python3.8 -m pip install --upgrade --no-cache-dir --target /usr/local/jina --progress-bar off $*
     # install jinad
-    python3.8 -m pip install --upgrade --target /usr/local/jina --progress-bar off --pre "jina[daemon]"
+    python3.8 -m pip install --upgrade --target /usr/local/jina --progress-bar off "jina[daemon]"
     chmod -R 777 /usr/local/jina
 INIT
 


### PR DESCRIPTION
We are currently installing the pre version for use with JinaD.
Merging the RC1 for 2.0 is currently breaking JinaD.
I think we should rather use the latest proper release here instead of pre?