### PR TITLE
added kubernetes deployment manifests for quickstart use-case

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,0 +1,40 @@
+# Running jina demo on kubernetes
+
+## Deploy jina demo to the cluster in default namespace and use port-forward to access the GUI
+
+- kubectl apply -f https://raw.githubusercontent.com/longwuyuan/cloud-ops/master/kubernetes/manifests/jina-k8s.yaml
+
+- kubectl port-forward service/jina-k8s 12345:12345
+
+- In your browser, open the URL http://localhost:12345
+
+## For exposing jina outside the cluster, with ingress or "k8s-service: --type Loadbalancer"
+- Here is a example manifest for kubernetes resource of type Ingress. If you are using a ingress-controller, then you can use this example and modify the host spec, to create a ingress for this jina-demo
+
+```
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: jina-k8s
+spec:
+  rules:
+  - host: jina-k8s.dev.yourdomain.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: jina-k8s
+            port:
+              number: 12345
+```
+
+Alternatively, if you have the Loadbalancer capability in your kubernetes cluster (using AWS/GCE/Other LB or Metallb), you can use the command `kubectl -n jina expose deployment jina-k8s --type LoadBalancer --port 80 --target-port 12345 --name jina` 
+
+### TODO - Put nginx in front of gunicorn
+### TODO - Add kubectl kustomize support
+### TODO - Get with making the image official
+### TODO - Create operator and any other CRDs needed 

--- a/kubernetes/image/Dockerfile
+++ b/kubernetes/image/Dockerfile
@@ -1,0 +1,9 @@
+FROM python
+
+RUN pip3 install "jina[standard]" && apt update && apt install -y nginx
+
+ADD https://raw.githubusercontent.com/longwuyuan/cloud-ops/master/kubernetes/image/example.py /
+
+EXPOSE 12345
+
+ENTRYPOINT ["python3", "/example.py"]

--- a/kubernetes/image/example.py
+++ b/kubernetes/image/example.py
@@ -1,0 +1,35 @@
+import numpy as np
+from jina import Document, DocumentArray, Executor, Flow, requests
+
+class CharEmbed(Executor):  # a simple character embedding with mean-pooling
+    offset = 32  # letter `a`
+    dim = 127 - offset + 1  # last pos reserved for `UNK`
+    char_embd = np.eye(dim) * 1  # one-hot embedding for all chars
+
+    @requests
+    def foo(self, docs: DocumentArray, **kwargs):
+        for d in docs:
+            r_emb = [ord(c) - self.offset if self.offset <= ord(c) <= 127 else (self.dim - 1) for c in d.text]
+            d.embedding = self.char_embd[r_emb, :].mean(axis=0)  # average pooling
+
+class Indexer(Executor):
+    _docs = DocumentArray()  # for storing all documents in memory
+
+    @requests(on='/index')
+    def foo(self, docs: DocumentArray, **kwargs):
+        self._docs.extend(docs)  # extend stored `docs`
+
+    @requests(on='/search')
+    def bar(self, docs: DocumentArray, **kwargs):
+        q = np.stack(docs.get_attributes('embedding'))  # get all embeddings from query docs
+        d = np.stack(self._docs.get_attributes('embedding'))  # get all embeddings from stored docs
+        euclidean_dist = np.linalg.norm(q[:, None, :] - d[None, :, :], axis=-1)  # pairwise euclidean distance
+        for dist, query in zip(euclidean_dist, docs):  # add & sort match
+            query.matches = [Document(self._docs[int(idx)], copy=True, scores={'euclid': d}) for idx, d in enumerate(dist)]
+            query.matches.sort(key=lambda m: m.scores['euclid'].value)  # sort matches by their values
+
+f = Flow(port_expose=12345, protocol='http').add(uses=CharEmbed, parallel=2).add(uses=Indexer)  # build a Flow, with 2 parallel CharEmbed, tho unnecessary
+with f:
+    f.post('/index', (Document(text=t.strip()) for t in open(__file__) if t.strip()))  # index all lines of _this_ file
+    f.block()  # block for listening request
+

--- a/kubernetes/manifests/jina-k8s.yaml
+++ b/kubernetes/manifests/jina-k8s.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: jina-k8s
+  name: jina-k8s
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: jina-k8s
+  template:
+    metadata:
+      labels:
+        app: jina-k8s
+    spec:
+      containers:
+      - image: longwuyuan/jina-k8s
+        name: jina-k8s
+        ports:
+        - containerPort: 12345
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: jina-k8s
+  name: jina-k8s
+spec:
+  type: ClusterIP
+  ports:
+  - port: 12345
+    protocol: TCP
+    targetPort: 12345
+  selector:
+    app: jina-k8s


### PR DESCRIPTION
- Created a container image with ;
---
FROM python

RUN pip3 install "jina[standard]" && apt update && apt install -y nginx

ADD https://raw.githubusercontent.com/longwuyuan/cloud-ops/master/kubernetes/image/example.py /

EXPOSE 12345

ENTRYPOINT ["python3", "/example.py"]

---

- example.py is the minimum example from https://github.com/jina-ai/jina#get-started

- Then used `kubectl create deployment longwuyuan/jina-k8s --port 12345 --dry-run=clinet -o yaml` to generate manifest and put a service of type ClusterIP with it

- README contains some tips on ingress for that or a service of `--type Loadbalancer`