### PR TITLE
feat: add jina now uses cases to jcloud

### DIFF
--- a/.github/workflows/test-now-jcloud-workflow.yml
+++ b/.github/workflows/test-now-jcloud-workflow.yml
@@ -1,0 +1,96 @@
+name: (test-workflow) now-jcloud integration Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      release:
+        description: Pass the jina-now release
+        required: true
+        default: latest
+
+jobs:
+  now-prep-testbed:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout now repo
+        uses: actions/checkout@v3
+        with:
+          repository: jina-ai/now
+          fetch-depth: 0
+      - name: Get now latest tag
+        id: latest
+        uses: "WyriHaximus/github-action-get-previous-tag@v1"
+      - id: set-matrix
+        run: |
+          sudo apt-get install jq
+          echo "::set-output name=matrix::$(bash scripts/get-all-test-paths.sh)"
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      tag: ${{ steps.latest.outputs.tag }}
+
+  now-integration-tests:
+    needs: now-prep-testbed
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        test-path: ${{fromJson(needs.now-prep-testbed.outputs.matrix)}}
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - name: Read secrets from AWS Secrets Manager into environment variables
+        uses: abhilash1in/aws-secrets-manager-action@v2.1.0
+        with:
+          secrets: |
+            AWS_ACCESS_KEY_ID
+            AWS_HOSTED_ZONE_ID
+            AWS_SECRET_ACCESS_KEY
+            DOCKER_PASSWORD
+            DOCKER_USERNAME
+            HUBBLE_AUTH_TOKEN
+            JINA_DEV_BOT
+            JINA_OPTOUT_TELEMETRY
+            NETLIFY_AUTH_TOKEN1
+            NETLIFY_SITE_ID
+            NOW_ANNLITE_EXECUTOR_SECRET
+            NOW_AUTH_EXECUTOR_SECRET
+            NOW_AUTOCOMPLETE_SECRET
+            NOW_ELASTIC_EXECUTOR_SECRET
+            NOW_OCR_EXECUTOR_SECRET
+            NOW_POSTPROCESSOR_EXECUTOR_SECRET
+            NOW_PREPROCESSOR_JCLOUD_TOKEN
+            NOW_PREPROCESSOR_REPO
+            NOW_PREPROCESSOR_REPO_TOKEN
+            NOW_QDRANT_EXECUTOR_SECRET
+            NOW_STAGING_FLORIAN
+            PERSONAL_ACCESS_TOKEN
+            S3_IMAGE_TEST_DATA_PATH
+            TWINE_PASSWORD
+            TWINE_USERNAME
+            WOLF_EXAMPLES_TOKEN
+            WOLF_TOKEN
+      - name: Checkout now repo
+        uses: actions/checkout@v3
+        with:
+          repository: jina-ai/now
+          ref: ${{ needs.now-prep-testbed.outputs.tag }}
+      - name: Setup Python 3.7
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: Prepare environment
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install wheel
+          export JCLOUD_LOGLEVEL=DEBUG
+          pip install --no-cache-dir -r requirements.txt
+          pip install --no-cache-dir -r requirements-test.txt
+      - name: Run tests
+        run: |
+          pytest -v -m remote ${{ matrix.test-path }}
+        env:
+          JCLOUD_API: https://api-ci-episr.wolf.jina.ai


### PR DESCRIPTION
This PR adds a test github action to run `jina-ai/now` tests on operator integration tests